### PR TITLE
[BUG] credentials.ini under $HOME instead of root

### DIFF
--- a/alibabacloud_credentials/providers.py
+++ b/alibabacloud_credentials/providers.py
@@ -489,7 +489,7 @@ class ProfileCredentialsProvider(AlibabaCloudCredentialsProvider):
         if file_path is None:
             if not ac.HOME:
                 return
-            file_path = os.path.join(ac.HOME, "/.alibabacloud/credentials.ini")
+            file_path = os.path.join(ac.HOME, ".alibabacloud/credentials.ini")
         if len(file_path) == 0:
             raise CredentialException("The specified credentials file is empty")
 


### PR DESCRIPTION
According to [Credentials 设置](https://help.aliyun.com/document_detail/378659.html), the credentials.ini should be placed at `~/.alibabacloud/credentials.ini` instead of `/.alibabacloud/credentials.ini`.

It is the misusage of `os.path.join()` that leads to this bug. Please refer to this [blog](https://blog.csdn.net/weixin_37895339/article/details/79185119) for details.