### PR TITLE
fix: build failure caused by not correctly retrieving the version during the build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 """
 
 import os
+import re
 import sys
 from setuptools import setup, find_packages
 
@@ -31,9 +32,18 @@ AUTHOR = "Alibaba Cloud"
 AUTHOR_EMAIL = "alibaba-cloud-sdk-dev-team@list.alibaba-inc.com"
 URL = "https://github.com/aliyun/credentials-python"
 TOPDIR = os.path.dirname(__file__) or "."
-VERSION = __import__(PACKAGE).__version__
 
-with open("README.md", encoding="utf-8") as fp:
+def read_version():
+    init_path = os.path.join(TOPDIR, PACKAGE, "__init__.py")
+    with open(init_path, encoding="utf-8") as f:
+        m = re.search(r'^__version__\s*=\s*[\'"]([^\'"]+)[\'"]', f.read(), re.M)
+        if not m:
+            raise RuntimeError("Cannot find __version__ in {}".format(os.path.relpath(init_path)))
+        return m.group(1)
+
+VERSION = read_version()
+
+with open(os.path.join(TOPDIR, "README.md"), encoding="utf-8") as fp:
     LONG_DESCRIPTION = fp.read()
 
 install_requires = [


### PR DESCRIPTION
当我在执行
```python
pip install alibabacloud_credentials -U
```
时，会提示构建失败的错误消息：
```shell
Collecting alibabacloud-credentials
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/b7/0c/1b0c5f4c2170165719b336616ac0a88f1666fd8690fda41e2e8ae3139fd9/alibabacloud-credentials-1.0.2.tar.gz (30 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 35, in <module>
        File "D:\xxx\System\Temp\pip-install-fjnrk_89\alibabacloud-credentials_8d1bc2f0b418402a9128f01e8f12ef51\setup.py", line 34, in <module>
          VERSION = __import__(PACKAGE).__version__
                    ^^^^^^^^^^^^^^^^^^^
      ModuleNotFoundError: No module named 'alibabacloud_credentials'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

我想可能是因为它在生成元数据阶段就去 import 自己的模块拿版本号，但当前环境里还没有这个模块，于是构建错误。
此 PR 调整构建脚本，直接读取源文件中的 `__version__` 字面值，防止缺少依赖问题。