### PR TITLE
remove debug log statement in EXECUTOR shutdown callback

### DIFF
--- a/alibabacloud_credentials/provider/refreshable.py
+++ b/alibabacloud_credentials/provider/refreshable.py
@@ -26,7 +26,6 @@ EXECUTOR = ThreadPoolExecutor(max_workers=INT64_MAX, thread_name_prefix='non-blo
 
 
 def _shutdown_handler():
-    log.debug("Shutting down executor...")
     EXECUTOR.shutdown(wait=False)
 
 


### PR DESCRIPTION
Using the signals module the library tries to gracefully shutdown the ThreadPoolExecutor with a callback.

For us this causes some issues with the logger module warning that you're writing to write to a log file after the file is closed. With these signal callbacks you can't control the shutdown order.

```
Traceback (most recent call last):
  File "/Users/psnelgrove/.local/share/uv/python/cpython-3.10.15-macos-aarch64-none/lib/python3.10/logging/__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "/Users/psnelgrove/code/.../.venv/lib/python3.10/site-packages/alibabacloud_credentials/provider/refreshable.py", line 27, in _shutdown_handler
    log.debug("Shutting down executor...")
Message: 'Shutting down executor...'
Arguments: ()
```